### PR TITLE
Fixed rmap for usage on github.

### DIFF
--- a/org.palladiosimulator.thirdpartywrapper.buckminster/thirdpartywrapper.rmap
+++ b/org.palladiosimulator.thirdpartywrapper.buckminster/thirdpartywrapper.rmap
@@ -26,10 +26,13 @@
     <rm:provider componentTypes="osgi.bundle,eclipse.feature" resolutionFilter="(resolveFrom=release)" readerType="p2" source="false" mutable="false">
       <rm:uri format="http://sdqweb.ipd.kit.edu/eclipse/thirdpartywrapper/releases/latest/" />
     </rm:provider>
-    <rm:provider componentTypes="eclipse.feature,osgi.bundle" readerType="svn">
-      <rm:uri format="https://anonymous:anonymous@svnserver.informatik.kit.edu/i43/svn/code/ThirdPartyWrapper/trunk/{0}?moduleAfterTag&amp;moduleAfterBranch">
-        <bc:propertyRef key="buckminster.component"/>
+    <rm:provider componentTypes="eclipse.feature,osgi.bundle" readerType="git" source="true">
+      <rm:uri format="{0}/GIT,{1}">
+        <bc:propertyRef key="workspace.root" />
+        <bc:propertyRef key="buckminster.component" />
       </rm:uri>
+      <rm:property key="git.remote.uri" value="https://github.com/PalladioSimulator/Palladio-ThirdParty-Library"/>
+      <rm:property key="git.auto.fetch" value="true"/>
     </rm:provider>
   </rm:searchPath>
 


### PR DESCRIPTION
The rmap is not compatible with Github yet. I replaced the link to SVN with a link to Github. This should fix the build.